### PR TITLE
Update python alias to python3 for macOS

### DIFF
--- a/source/40_osx.sh
+++ b/source/40_osx.sh
@@ -12,4 +12,4 @@ fi
 
 # Set default Python3 to the version managed by Homebrew
 # The macOS version of Python3 is totally broken
-alias python3=/usr/local/bin/python3
+alias python=/usr/bin/python3


### PR DESCRIPTION
Recent versions of macOS have removed python 2.x from the system. Point to python3.