### PR TITLE
Remove thefuck package references

### DIFF
--- a/init/20_ubuntu_apt.sh
+++ b/init/20_ubuntu_apt.sh
@@ -149,7 +149,6 @@ apt_packages+=(
   python3-notebook
   python3-pip
   software-properties-common
-  thefuck
   tmux
   vim
   # Desktop packages

--- a/init/30_osx_homebrew_recipes.sh
+++ b/init/30_osx_homebrew_recipes.sh
@@ -19,7 +19,6 @@ recipes=(
     neovim
     postgresql
     reattach-to-user-namespace
-    thefuck
     tmux
     tmux-xpanes
     tree

--- a/source/20_aliases.sh
+++ b/source/20_aliases.sh
@@ -17,9 +17,6 @@ alias tma="tmux a -t BRENDANOROURKE"
 alias tmn="tmux new -s BRENDANOROURKE -n HipsterSh\#\%"
 alias tmk="tmux kill-session"
 
-# The fuck
-eval $(thefuck --alias)
-
 # Ask for ssh passphrase once
 alias ssha="eval $(ssh-agent) && ssh-add"
 


### PR DESCRIPTION
## Summary
- remove thefuck from the Ubuntu apt package list
- remove thefuck from the macOS Homebrew recipes
- drop thefuck alias initialization from shell aliases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1bca7dd08832f9979a8d2bdf146c0